### PR TITLE
Ready for Symfony 5

### DIFF
--- a/DataCollector/LdapToolsDataCollector.php
+++ b/DataCollector/LdapToolsDataCollector.php
@@ -57,7 +57,7 @@ class LdapToolsDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
         if (!$this->ldap) {
             return;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,8 +39,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ldap_tools');
+        $treeBuilder = new TreeBuilder('ldap_tools');
+        $rootNode = $treeBuilder->getRootNode();
+        //$rootNode = $treeBuilder->root('ldap_tools');
         $this->addMainSection($rootNode);
         $this->addDoctrineSection($rootNode);
         $this->addGeneralSection($rootNode);

--- a/Doctrine/Subscriber/LdapObjectSubscriber.php
+++ b/Doctrine/Subscriber/LdapObjectSubscriber.php
@@ -255,7 +255,7 @@ class LdapObjectSubscriber implements EventSubscriber
      */
     protected function getObjectFromLifeCycleArgs(LifecycleEventArgs $args)
     {
-        $rc = new \ReflectionClass('Doctrine\Common\Persistence\Event\LifecycleEventArgs');
+        $rc = new \ReflectionClass('Doctrine\Persistence\Event\LifecycleEventArgs');
 
         if ($rc->hasMethod('getObject')) {
             return $args->getObject();
@@ -272,7 +272,7 @@ class LdapObjectSubscriber implements EventSubscriber
      */
     protected function getOmFromLifeCycleArgs(LifecycleEventArgs $args)
     {
-        $rc = new \ReflectionClass('Doctrine\Common\Persistence\Event\LifecycleEventArgs');
+        $rc = new \ReflectionClass('Doctrine\Persistence\Event\LifecycleEventArgs');
 
         if ($rc->hasMethod('getObjectManager')) {
             return $args->getObjectManager();

--- a/Doctrine/Subscriber/LdapObjectSubscriber.php
+++ b/Doctrine/Subscriber/LdapObjectSubscriber.php
@@ -14,7 +14,7 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\ObjectManager;
 use LdapTools\Bundle\LdapToolsBundle\Annotation\LdapObject as LdapObjectAnnotation;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use LdapTools\LdapManager;
 use LdapTools\Object\LdapObject;
 use LdapTools\Object\LdapObjectCollection;

--- a/Event/AuthenticationHandlerEvent.php
+++ b/Event/AuthenticationHandlerEvent.php
@@ -10,7 +10,7 @@
 
 namespace LdapTools\Bundle\LdapToolsBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;

--- a/Event/LdapLoginEvent.php
+++ b/Event/LdapLoginEvent.php
@@ -11,7 +11,7 @@
 namespace LdapTools\Bundle\LdapToolsBundle\Event;
 
 use LdapTools\Bundle\LdapToolsBundle\Security\User\LdapUser;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 

--- a/Event/LoadUserEvent.php
+++ b/Event/LoadUserEvent.php
@@ -12,7 +12,7 @@ namespace LdapTools\Bundle\LdapToolsBundle\Event;
 
 use LdapTools\Bundle\LdapToolsBundle\Security\User\LdapUser;
 use LdapTools\Object\LdapObject;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**

--- a/Security/LdapGuardAuthenticator.php
+++ b/Security/LdapGuardAuthenticator.php
@@ -236,7 +236,7 @@ class LdapGuardAuthenticator extends AbstractGuardAuthenticator
             $token,
             $providerKey
         );
-        $this->dispatcher->dispatch(AuthenticationHandlerEvent::SUCCESS, $event);
+        $this->dispatcher->dispatch($event, AuthenticationHandlerEvent::SUCCESS);
 
         return $this->options['http_basic'] ? null : $event->getResponse();
     }
@@ -251,7 +251,7 @@ class LdapGuardAuthenticator extends AbstractGuardAuthenticator
             $request,
             $exception
         );
-        $this->dispatcher->dispatch(AuthenticationHandlerEvent::FAILURE, $event);
+        $this->dispatcher->dispatch($event, AuthenticationHandlerEvent::FAILURE);
 
         return $this->options['http_basic'] ? null : $event->getResponse();
     }
@@ -267,7 +267,7 @@ class LdapGuardAuthenticator extends AbstractGuardAuthenticator
             $request,
             $authException
         );
-        $this->dispatcher->dispatch(AuthenticationHandlerEvent::START, $event);
+        $this->dispatcher->dispatch($event, AuthenticationHandlerEvent::START);
 
         return $event->getResponse();
     }

--- a/Security/LdapGuardAuthenticator.php
+++ b/Security/LdapGuardAuthenticator.php
@@ -211,8 +211,7 @@ class LdapGuardAuthenticator extends AbstractGuardAuthenticator
             $token = new UsernamePasswordToken($user, $credentials['password'], 'ldap-tools', $user->getRoles());
             $token->setAttribute('ldap_domain', $credDomain);
             $this->dispatcher->dispatch(
-                LdapLoginEvent::SUCCESS,
-                new LdapLoginEvent($user, $token)
+               new LdapLoginEvent($user, $token), LdapLoginEvent::SUCCESS
             );
         } catch (\Exception $e) {
             $this->hideOrThrow($e, $this->options['hide_user_not_found_exceptions']);

--- a/Security/User/LdapUser.php
+++ b/Security/User/LdapUser.php
@@ -11,14 +11,15 @@
 namespace LdapTools\Bundle\LdapToolsBundle\Security\User;
 
 use LdapTools\Object\LdapObject;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+//use Symfony\Component\Security\Core\User\AdvancedUserInterface; // No more in Symfony 5
 
 /**
  * Represents a user from LDAP.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LdapUser extends LdapObject implements LdapUserInterface, AdvancedUserInterface, \Serializable
+class LdapUser extends LdapObject implements LdapUserInterface, UserInterface, \Serializable
 {
     /**
      * @var array The Symfony roles for this user.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ldaptools/ldaptools-bundle",
     "type": "symfony-bundle",
-    "description": "Provides easy LDAP integration for Symfony via LdapTools.",
+    "description": "Provides easy LDAP integration for Symfony via LdapTools. Test to make this compatible with ^5 DO NOT use in production",
     "keywords": [
         "LDAP",
         "Active Directory",
@@ -19,15 +19,15 @@
     ],
     "require": {
         "ldaptools/ldaptools": ">=0.25",
-        "symfony/framework-bundle": "~2.7|~3.0|~4.0"
+        "symfony/framework-bundle": "~3.0|~4.0|~5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~1.0",
         "phpspec/phpspec": "~3.0",
         "akeneo/phpspec-skip-example-extension": "~2.0",
         "doctrine/orm": "~2.4",
-        "symfony/form": "~2.7|~3.0|~4.0",
-        "symfony/security-bundle": "~2.7|~3.0|~4.0"
+        "symfony/form": "~3.0|~4.0|~5.0",
+        "symfony/security-bundle": "~4.0|~5.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For LDAP object type integration in Doctrine."


### PR DESCRIPTION
This should be revised before merging. 
Currently testing it with: 

**Symfony** framework 5.4
**doctrine/orm**  2.13.3

All seems to work as expected but someone else has to try it. 
Note that I removed support for Symfony 2.7 and added ^5 in the composer.json
If it's tested by others and proved to be working it would be nice to have a new release so other developers can use it too.